### PR TITLE
Make CORS work when using credentials.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,10 @@ app.use( express.bodyParser() );
 // ## CORS middleware
 // see: http://stackoverflow.com/questions/7067966/how-to-allow-cors-in-express-nodejs
 var allowCrossDomain = function(req, res, next) {
-    res.header('Access-Control-Allow-Origin', '*');
-    res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
+    res.header('Access-Control-Allow-Origin', req.header('Origin'));
+    res.header('Access-Control-Allow-Methods', 'OPTIONS,GET,PUT,POST,DELETE');
     res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    res.header('Access-Control-Allow-Credentials', 'true');
       
     // intercept OPTIONS method
     if ('OPTIONS' == req.method) {


### PR DESCRIPTION
CORS requests containing credentials (cookie, authorization header) require the credentials flag to be set to true.
